### PR TITLE
chore: add vitest config and upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "prettier": "^3.2.5",
                 "typescript": "^5.3.3",
                 "vite": "^5.2.0",
-                "vitest": "^1.6.0"
+                "vitest": "^1.6.1"
             },
             "engines": {
                 "node": ">=18.18"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "prettier": "^3.2.5",
         "typescript": "^5.3.3",
         "vite": "^5.2.0",
-        "vitest": "^1.6.0"
+        "vitest": "^1.6.1"
     },
     "browserslist": [
         "defaults",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
+import { configDefaults } from 'vitest/config';
 
 // NOTE on base path:
 // - Local dev:        "/"
@@ -68,5 +69,11 @@ export default defineConfig(({ mode }) => {
 
     // Avoid injecting non‑deterministic compile‑time constants here to keep builds reproducible
     define: {},
+
+    test: {
+      globals: true,
+      environment: 'node',
+      exclude: [...configDefaults.exclude, 'node_modules'],
+    },
   };
 });


### PR DESCRIPTION
## Summary
- upgrade Vitest dev dependency
- integrate Vitest config into Vite setup

## Testing
- `npm run typecheck`
- `npx vitest@1.6.1 run`


------
https://chatgpt.com/codex/tasks/task_e_68bb95b5536c832f81f6edb5b5e7ab97