### PR TITLE
Fix GitHub Pages routing and export fallback

### DIFF
--- a/app/main.tsx
+++ b/app/main.tsx
@@ -24,28 +24,31 @@ import AuthGate from '@/components/AuthGate'
 import TerminalBoot from '@/components/TerminalBoot'
 
 // Boot gate: show TerminalBoot first, then /login
-const BootRedirect = () => <Navigate to="/login" replace />
+const BootRedirect = () => <Navigate to="login" replace />
 
-const router = createBrowserRouter([
-  { path: '/', element: <BootRedirect /> },
-  { path: '/login', element: <LoginPage /> },
-  {
-    path: '/dashboard',
-    element: (
-      <AuthGate>
-        <Layout />
-      </AuthGate>
-    ),
-    children: [
-      { index: true, element: <DashboardPage /> },
-      { path: 'roadmap', element: <RoadmapPage /> },
-      { path: 'audit', element: <AuditPage /> },
-      { path: 'content', element: <ContentPage /> },
-      { path: 'news', element: <NewsPage /> },
-    ],
-  },
-  { path: '*', element: <Navigate to="/" replace /> },
-])
+const router = createBrowserRouter(
+  [
+    { path: '/', element: <BootRedirect /> },
+    { path: '/login', element: <LoginPage /> },
+    {
+      path: '/dashboard',
+      element: (
+        <AuthGate>
+          <Layout />
+        </AuthGate>
+      ),
+      children: [
+        { index: true, element: <DashboardPage /> },
+        { path: 'roadmap', element: <RoadmapPage /> },
+        { path: 'audit', element: <AuditPage /> },
+        { path: 'content', element: <ContentPage /> },
+        { path: 'news', element: <NewsPage /> },
+      ],
+    },
+    { path: '*', element: <Navigate to="/" replace /> },
+  ],
+  { basename: import.meta.env.BASE_URL }
+)
 
 function mount() {
   const el = document.getElementById('root')

--- a/tools/export.ts
+++ b/tools/export.ts
@@ -29,6 +29,11 @@ export function buildExport(root = process.cwd()){
 
   copyDir(dist, siteDir);
 
+  // SPA fallback for GitHub Pages
+  const indexHtml = fs.readFileSync(path.join(siteDir, 'index.html'), 'utf8');
+  fs.writeFileSync(path.join(siteDir, '404.html'), indexHtml);
+  fs.writeFileSync(path.join(siteDir, '.nojekyll'), '');
+
   // 4) Write export meta
   const meta = {
     at: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Configure React Router with Vite's BASE_URL and adjust boot redirect for GitHub Pages
- Add SPA fallback (404.html) and .nojekyll in export bundle

## Testing
- `npm test -- --run`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bba8c6f1b8832fa1346a73831ee577