### PR TITLE
Fix type prop usage to restore typecheck success

### DIFF
--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -58,7 +58,7 @@ export default function Layout() {
                 <NavLink
                   key={item.to}
                   to={item.to}
-                  end={item.end}
+                  end={Boolean(item.end)}
                   className={({ isActive }) => (isActive ? 'ax-tab is-active' : 'ax-tab')}
                 >
                   {item.label}

--- a/app/routes/dashboard/roadmap/page.tsx
+++ b/app/routes/dashboard/roadmap/page.tsx
@@ -121,7 +121,7 @@ export default function RoadmapPage() {
       )}
 
       <PreviewPane
-        src={previewSrc ?? undefined}
+        src={previewSrc ?? null}
         title='AXIOM Roadmap'
         reloadToken={`${reloadKey}-${selected ?? 'none'}`}
         leadingControls={sourceControls}


### PR DESCRIPTION
## Summary
- coerce optional navigation link `end` flag to a strict boolean to satisfy exact optional property typings
- ensure preview pane receives null when no source is available to match its prop contract

## Testing
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf3af69f10832f9167e083ff1b6624